### PR TITLE
fix: incorrect osd popout colors

### DIFF
--- a/src/theme.css
+++ b/src/theme.css
@@ -29,8 +29,9 @@
 }
 
 .formDialogHeader:not(.formDialogHeader-clear),
-.formDialogFooter:not(.formDialogFooter-clear) {
-  background-color: var(--second-background);
+.formDialogFooter:not(.formDialogFooter-clear),
+.cardBox:not(.visualCardBox) .cardPadder {
+  background-color: var(--hover-background);
 }
 
 .backgroundContainer,
@@ -48,7 +49,7 @@ html {
 }
 
 .sliderBubble,
-.skinHeader,
+.skinHeader:not(.osdHeader),
 .nowPlayingBar {
   color: var(--main-text);
   background-color: var(--second-background) !important;
@@ -118,7 +119,7 @@ html {
 .listItem:focus,
 .navMenuOption:hover,
 .navMenuOption:focus {
-  color: var(--main-color);
+  color: var(--main-color) !important;
   background-color: var(--hover-background);
 }
 
@@ -190,7 +191,8 @@ html {
 .emby-button-foreground:focus,
 .mdl-slider,
 .headerRight,
-.headerLeft {
+.headerLeft,
+.button-link {
   color: var(--main-color);
 }
 
@@ -294,4 +296,20 @@ legend {
 .sessionAppName,
 .sessionNowPlayingInfo {
   color: var(--main-background);
+}
+
+.iconOsd {
+  background-color: var(--second-background);
+}
+
+.iconOsd .iconOsdIcon {
+  color: var(--main-text);
+}
+
+.iconOsdProgressOuter {
+  background-color: var(--hover-background);
+}
+
+.iconOsdProgressInner {
+  background-color: var(--main-color);
 }

--- a/src/theme.css
+++ b/src/theme.css
@@ -21,14 +21,15 @@
 .mdl-slider::-webkit-slider-thumb {background-color: var(--main-color);}
 .mdl-slider::-moz-range-thumb {background-color: var(--main-color);}
 
+.navMenuOption-selected,
+.listItemButton:focus,
+.iconOsdProgressInner,
 .mdl-slider-background-lower {
   background-color: var(--main-color);
 }
 
-.mdl-slider-background-flex {
-  background-color: var(--hover-background);
-}
-
+.iconOsdProgressOuter,
+.mdl-slider-background-flex,
 .formDialogHeader:not(.formDialogHeader-clear),
 .formDialogFooter:not(.formDialogFooter-clear),
 .cardBox:not(.visualCardBox) .cardPadder {
@@ -66,14 +67,6 @@ html {
   background: var(--main-background);
 }
 
-.navMenuOption-selected {
-  background-color: var(--main-color);
-}
-
-.itemName {
-  color: var(--main-text);
-}
-
 .playstatebutton-icon-played,
 .ratingbutton-icon-withrating {
   color: var(--red-color);
@@ -104,14 +97,6 @@ html {
 .raised {
   color: var(--main-text);
   background-color: var(--second-background);
-}
-
-.emby-button-foreground {
-  color: var(--main-text);
-}
-
-.paper-icon-button-light {
-  color: var(--main-text);
 }
 
 .paper-icon-button-light:hover:not(:disabled),
@@ -198,10 +183,6 @@ html {
   color: var(--main-color);
 }
 
-.mdl-slider::-moz-range-thumb {
-  background-color: var(--main-color);
-}
-
 .MuiButtonBase-root,
 .MuiSvgIcon-root,
 .listItemButton,
@@ -227,10 +208,6 @@ html {
 
 .MuiToolbar-root {
   background-color: var(--main-background);
-}
-
-.listItemButton:focus {
-  background-color: var(--main-color);
 }
 
 .indicator {
@@ -280,6 +257,10 @@ html {
 .navMenuOption,
 .inputLabel,
 .content-primary,
+.itemName,
+.paper-icon-button-light,
+.emby-button-foreground,
+.iconOsd .iconOsdIcon,
 legend {
   color: var(--main-text);
 }
@@ -301,18 +282,6 @@ legend {
 
 .iconOsd {
   background-color: var(--second-background);
-}
-
-.iconOsd .iconOsdIcon {
-  color: var(--main-text);
-}
-
-.iconOsdProgressOuter {
-  background-color: var(--hover-background);
-}
-
-.iconOsdProgressInner {
-  background-color: var(--main-color);
 }
 
 /* this has to be background, not background-color for some reason */


### PR DESCRIPTION
- Themes the popout that shows when changing volume.
![2025-03-01-190331_hyprshot](https://github.com/user-attachments/assets/43728f9f-dd0d-40bf-98d0-2829547c6ed0)
- Removes background color from header in the video player
