### PR TITLE
fix: incorrect image size & indicator color

### DIFF
--- a/themes/theme.css
+++ b/themes/theme.css
@@ -186,7 +186,10 @@ html {
 .MuiSvgIcon-root,
 .listItemButton,
 .checkboxListLabel,
-.lnkMediaFolder {
+.lnkMediaFolder,
+.sessionAppName,
+.sessionNowPlayingInfo,
+.sessionNowPlayingTime {
   color: var(--main-text) !important;
 }
 
@@ -285,7 +288,7 @@ legend {
   background-color: var(--second-background);
 }
 
-.osdTextContainer, .osdTimeText, .cardContent div {
+.osdTextContainer, .osdTimeText {
   color: var(--main-text);
 }
 

--- a/themes/theme.css
+++ b/themes/theme.css
@@ -305,9 +305,13 @@ div[role=presentation].jstree-wholerow-clicked {
   border-color: var(--main-color);
 }
 
-.infoBanner, .cardContent {
+.infoBanner {
   color: var(--main-text);
   background: var(--second-background);
+}
+
+.cardContent.defaultCardBackground {
+  background-color: var(--second-background);
 }
 
 .itemProgressBar.playbackProgress .itemProgressBarForeground {


### PR DESCRIPTION
This PR fixes stuff that my last PR broke.
For some reason, setting a `background` to a card box affects images.
